### PR TITLE
use snake case name as ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,13 @@ jobs:
           coverage: none
 
       - name: Obtain Composer cache directory
-        id: composer-cache
+        id: composer_cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache Composer dependencies
         uses: actions/cache@v1
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
+          path: ${{ steps.composer_cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -142,13 +142,13 @@ jobs:
         run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
 
       - name: Obtain NPM Cache directory (used by Laravel Mix)
-        id: node-cache-dir
+        id: node_cache_dir
         run: echo "::set-output name=dir::$(npm config get cache)" # Use $(yarn cache dir) for yarn
 
       - name: Cache NPM dependencies (used by Laravel Mix)
         uses: actions/cache@v1
         with:
-          path: ${{ steps.node-cache-dir.outputs.dir }}
+          path: ${{ steps.node_cache_dir.outputs.dir }}
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }} # Use '**/yarn.lock' for yarn
           restore-keys: ${{ runner.os }}-node-
 


### PR DESCRIPTION
when testing this action with https://github.com/nektos/act on Mac Os X.
I have a `Unable to interpolate string '${{ steps.composer-cache.outputs.dir }}' - [ReferenceError: 'cache' is not defined]`

```
[Deploy to staging/Check out, build and deploy using Vapor]   ⚙  ::set-output:: dir=/github/home/.composer/cache/files
[Deploy to staging/Check out, build and deploy using Vapor]   ✅  Success - Obtain Composer cache directory
ERRO[0046] Unable to interpolate string '${{ steps.composer-cache.outputs.dir }}' - [ReferenceError: 'cache' is not defined] 
```

replace "composer-cache" to "composer_cache" fix the problem.

## Advanced setting that work for me :

```
name: Deploy to staging

jobs:
  vapor:
    name: Check out, build and deploy using Vapor
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v2

      - name: Setup PHP (w/ extensions) & Composer
        uses: shivammathur/setup-php@v2
        with:
          php-version: 7.3
          extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, dom, filter, gd, iconv, json, mbstring, pdo
          coverage: none

      - name: Obtain Composer cache directory
        id: composer_cache
        run: |
          echo "::set-output name=dir::$(composer config cache-files-dir)"

      - name: Cache Composer dependencies
        uses: actions/cache@v2
        with:
          path: ${{ steps.composer_cache.outputs.dir }}
          # Use composer.json for key, if composer.lock is not committed.
          # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
          restore-keys: ${{ runner.os }}-composer-

      - name: Install Vapor CLI Globally
        run: composer global require laravel/vapor-cli

      - name: Install Composer dependencies
        run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader

      - name: Obtain NPM Cache directory (used by Laravel Mix)
        id: node_cache_dir
        run: |
          echo "::set-output name=dir::$(npm config get cache)" # Use $(yarn cache dir) for yarn

      - name: Cache NPM dependencies (used by Laravel Mix)
        uses: actions/cache@v2
        with:
          path: ${{ steps.node_cache_dir.outputs.dir }}
          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }} # Use '**/yarn.lock' for yarn
          restore-keys: ${{ runner.os }}-node-

      - name: Deploy using Laravel Vapor
        env:
          VAPOR_API_TOKEN: ${{ secrets.VAPOR_API_TOKEN }}
        run: /github/home/.composer/vendor/bin/vapor deploy staging
```